### PR TITLE
Web project needs to deploy after the API project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ workflows:
           requires:
             - build_web
             - build_api
+            - deploy_api
           filters:
             branches:
               only: master


### PR DESCRIPTION
The Heroku free account won't allow two different applications to be deployed at the same time.